### PR TITLE
Update ToolShed dev repository link for GraphicsMagick tool

### DIFF
--- a/tools/image_processing/graphicsmagick/.shed.yml
+++ b/tools/image_processing/graphicsmagick/.shed.yml
@@ -9,7 +9,7 @@ long_description: |
   collection of tools and libraries which support reading, writing, and manipulating an
   image in over 88 major formats including important formats like DPX, GIF, JPEG, JPEG-2000, PNG, PDF, PNM, and TIFF.
 
-remote_repository_url: https://github.com/bgruening/galaxytools/new/gm/tools/image_processing/image_processing/
+remote_repository_url: https://github.com/bgruening/galaxytools/tree/master/tools/image_processing/graphicsmagick
 type: unrestricted
 categories:
   - Imaging


### PR DESCRIPTION
This PR updates the ToolShed metadata to include the correct development repository URL for the GraphicsMagick tool:

🔗 https://github.com/bgruening/galaxytools/tree/master/tools/image_processing/graphicsmagick

This helps ensure proper attribution and discoverability of the source code from the ToolShed page.